### PR TITLE
Remove incompatibility with Krastorio 2 Assets

### DIFF
--- a/info.json
+++ b/info.json
@@ -7,10 +7,9 @@
   "factorio_version": "1.1",
   "dependencies": [
     "base >= 1.1",
-    "! Krastorio2 >= 0.0.1",
-    "! Krastorio2Assets >= 0.0.1",
-    "! IndustrialRevolution >= 0.0.1",
-    "! IndustrialRevolution3 >= 0.0.1",
+    "! Krastorio2",
+    "! IndustrialRevolution",
+    "! IndustrialRevolution3",
     "(?) underwater-pipes",
     "(?) underground-pipe-pack"
   ],


### PR DESCRIPTION
Hi,

I got a report on one of my mods that it wasn't playable in combination with this mod since it depends on Krastorio 2 Assets and this mod has it listed as incompatible, whilst i kinda get it to signal to the user that the mod isn't needed to play with this marking it as incompatible is really inconvenient and it cannot interfere with your mod anyways since it has no data and/or control stage, so yeah please remove the incompatibility for it.

Also, to mark stuff as incompatible you don't need >= 0.0.1 at all, so i took the liberty of removing those as well.